### PR TITLE
Исправлено множество ошибок, приводивших к флаканью тестов

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,10 +50,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2', {
+    androidTestCompile('com.android.support.test.espresso:espresso-contrib:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'appcompat-v7'

--- a/app/src/androidTest/java/korablique/recipecalculator/ui/foodstuffslist/ListOfFoodstuffsActivityTest.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/foodstuffslist/ListOfFoodstuffsActivityTest.java
@@ -1,5 +1,7 @@
 package korablique.recipecalculator.ui.foodstuffslist;
 
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
@@ -9,6 +11,7 @@ import android.widget.EditText;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -16,11 +19,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import korablique.recipecalculator.R;
-import korablique.recipecalculator.database.DatabaseThreadExecutor;
 import korablique.recipecalculator.database.DatabaseWorker;
 import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.ui.Card;
-import korablique.recipecalculator.util.InstantMainThreadExecutor;
+import korablique.recipecalculator.util.InjectableActivityTestRule;
+import korablique.recipecalculator.util.InstantDatabaseThreadExecutor;
+import korablique.recipecalculator.util.SyncMainThreadExecutor;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -34,32 +38,46 @@ import static org.hamcrest.Matchers.not;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class ListOfFoodstuffsActivityTest {
-    private DatabaseWorker databaseWorker;
+    private DatabaseWorker databaseWorker =
+            new DatabaseWorker(new SyncMainThreadExecutor(), new InstantDatabaseThreadExecutor());
+    private Long savedFoodstuffId;
 
     @Rule
     public ActivityTestRule<ListOfFoodstuffsActivity> mActivityRule =
-            new ActivityTestRule<>(ListOfFoodstuffsActivity.class);
+            InjectableActivityTestRule.forActivity(ListOfFoodstuffsActivity.class)
+                    .withInjector((ListOfFoodstuffsActivity activity) -> {
+                        activity.databaseWorker = databaseWorker;
+                    })
+                    .withManualStart() // Сначала добавим контент, затем будем стартовать.
+                    .build();
 
     @Before
     public void setUp() throws InterruptedException {
-        databaseWorker = new DatabaseWorker(new InstantMainThreadExecutor(), new DatabaseThreadExecutor());
-        mActivityRule.getActivity().databaseWorker = databaseWorker;
-
         Card.setAnimationDuration(0);
+
+        Context context = InstrumentationRegistry.getTargetContext();
         Foodstuff foodstuff1 = new Foodstuff("product1", -1, 10, 10, 10, 10);
         databaseWorker.saveFoodstuff(
-                mActivityRule.getActivity(),
+                context,
                 foodstuff1,
                 new DatabaseWorker.SaveFoodstuffCallback() {
             @Override
-            public void onResult(long id) {}
+            public void onResult(long id) {
+                savedFoodstuffId = id;
+            }
             @Override
             public void onDuplication() {
                 throw new RuntimeException("Видимо, продукт уже существует");
             }
         });
 
-        mActivityRule.getActivity().reload();
+        mActivityRule.launchActivity(null);
+    }
+
+    @After
+    public void tearDown() {
+        databaseWorker.deleteFoodstuff(mActivityRule.getActivity(), savedFoodstuffId);
+        savedFoodstuffId = null;
     }
 
     @Test

--- a/app/src/androidTest/java/korablique/recipecalculator/util/InjectableActivityFactory.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/util/InjectableActivityFactory.java
@@ -1,0 +1,96 @@
+package korablique.recipecalculator.util;
+
+import android.content.Intent;
+import android.support.test.runner.intercepting.SingleActivityFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import javax.inject.Inject;
+
+import korablique.recipecalculator.base.BaseActivity;
+import korablique.recipecalculator.dagger.ActivityInjector;
+
+/**
+ * Espresso во время тестирования Активити их сам создаёт и инициилизирует, но позволяет нам вмешаться
+ * в процесс создания, если мы дадим ему свою фабрику Активити - SingleActivityFactory.
+ * <p>
+ * В тестах нам требуется подсовывать ненастоящие Dagger-зависимости в Активити до вызова onCreate(),
+ * Espresso позволяет это сделать только взяв на себя создание Активити (передачей SingleActivityFactory)
+ * с ручным созданием и инициилизацией Активити.
+ * <p>
+ * Данный класс является наследником SingleActivityFactory, и создан специально для возможности
+ * создания Активити с вручную проинициилизированными @Inject-полями.
+ */
+class InjectableActivityFactory<T extends BaseActivity> extends SingleActivityFactory<T> {
+    private final ActivityInjector<T> injectionPerformer;
+
+    InjectableActivityFactory(
+            Class<T> activityClassToIntercept, ActivityInjector<T> injectionPerformer) {
+        super(activityClassToIntercept);
+        this.injectionPerformer = injectionPerformer;
+    }
+
+    @Override
+    protected T create(Intent intent) {
+        T activity = createActivity();
+
+        activity.setIntent(intent);
+        setInjectionPerformerTo(activity);
+
+        return activity;
+    }
+
+    private T createActivity() {
+        Constructor<T> constructor;
+        try {
+            constructor = getActivityClassToIntercept().getConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("All activities must have constructors with 0 arguments", e);
+        }
+
+        T activity;
+        try {
+            activity = constructor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Couldn't create Activity", e);
+        }
+        return activity;
+    }
+
+    private void setInjectionPerformerTo(T activity) {
+        // В данном методе мы могли бы сделать только 1 вызов:
+        // 'activity.setInjector(injectionPerformer)`,
+        // но тогда мы бы не смогли затем проверить, что все @Inject-поля проинициилизированы.
+        // Чтобы осуществить такую проверку, мы создаём свой ActivityInjector и уже внутри
+        // него используем объект, который нам передали в конструкторе.
+
+        ActivityInjector<T> realInjectionPerformer = (T injectedActivity) -> {
+            // Выполняем инъекцию.
+            injectionPerformer.inject(injectedActivity);
+
+            // Убеждаемся, что все @Inject-поля были заданы.
+            for (Field field : injectedActivity.getClass().getDeclaredFields()) {
+                if (field.isAnnotationPresent(Inject.class)) {
+                    // Если поле не public - без вызова setAccessible мы получим тут SecurityException.
+                    field.setAccessible(true);
+
+                    Object fieldValue;
+                    try {
+                        fieldValue = field.get(injectedActivity);
+                    } catch (IllegalAccessException e) {
+                        throw new IllegalStateException(
+                                "Couldn't check @Inject field value", e);
+                    }
+
+                    if (fieldValue == null) {
+                        throw new IllegalStateException(
+                                "Given injector didn't set the '" + field.getName() + "' field!");
+                    }
+                }
+            }
+        };
+
+        activity.setInjector(realInjectionPerformer);
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/util/InjectableActivityTestRule.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/util/InjectableActivityTestRule.java
@@ -1,0 +1,59 @@
+package korablique.recipecalculator.util;
+
+import android.content.Intent;
+import android.support.test.rule.ActivityTestRule;
+
+import korablique.recipecalculator.base.BaseActivity;
+import korablique.recipecalculator.dagger.ActivityInjector;
+
+/**
+ * Rule для Espresso, которое необходимо использовать вместо ActivityTestRule, если Активити
+ * содержит какие-либо @Inject-поля, которые требуется проинициилизировать самостоятельно,
+ * мимо Даггера.
+ */
+public class InjectableActivityTestRule<T extends BaseActivity> extends ActivityTestRule<T> {
+    // Паттерн 'Builder'.
+    public static class Builder<BT extends BaseActivity> {
+        private final Class<BT> activityClass;
+        private ActivityInjector injector;
+        private boolean shouldStartImmediately = true;
+
+        private Builder(Class<BT> activityClass) {
+            this.activityClass = activityClass;
+        }
+
+        /**
+         * Задаем свой инжектор.
+         */
+        public Builder<BT> withInjector(ActivityInjector<BT> injector) {
+            this.injector = injector;
+            return this;
+        }
+
+        /**
+         * Устанавливаем форсированный ручной старт - активити не стартует сама до вызова
+         * {@link ActivityTestRule#launchActivity(Intent)}.
+         */
+        public Builder<BT> withManualStart() {
+            this.shouldStartImmediately = false;
+            return this;
+        }
+
+        public InjectableActivityTestRule<BT> build() {
+            if (injector == null) {
+                throw new IllegalStateException("withInjector() was not called");
+            }
+            return new InjectableActivityTestRule<>(this);
+        }
+    }
+
+    public static <BT extends BaseActivity> Builder<BT> forActivity(Class<BT> activityClass) {
+        return new Builder<>(activityClass);
+    }
+
+    private InjectableActivityTestRule(Builder<T> builder) {
+        super(new InjectableActivityFactory<T>(builder.activityClass, builder.injector),
+                false,
+                builder.shouldStartImmediately);
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/util/SyncMainThreadExecutor.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/util/SyncMainThreadExecutor.java
@@ -1,0 +1,14 @@
+package korablique.recipecalculator.util;
+
+import android.app.Instrumentation;
+import android.os.Looper;
+import android.support.test.InstrumentationRegistry;
+
+import korablique.recipecalculator.base.MainThreadExecutor;
+
+public class SyncMainThreadExecutor extends MainThreadExecutor {
+    @Override
+    public void execute(Runnable runnable) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(runnable);
+    }
+}

--- a/app/src/main/java/korablique/recipecalculator/base/BaseActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/base/BaseActivity.java
@@ -1,4 +1,4 @@
-package korablique.recipecalculator.ui;
+package korablique.recipecalculator.base;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -15,18 +15,34 @@ import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 import java.util.ArrayList;
 import java.util.List;
 
-import dagger.android.AndroidInjection;
 import korablique.recipecalculator.R;
+import korablique.recipecalculator.dagger.ActivityInjector;
+import korablique.recipecalculator.dagger.DefaultActivityInjector;
 import korablique.recipecalculator.ui.calculator.CalculatorActivity;
 import korablique.recipecalculator.ui.history.HistoryActivity;
 import korablique.recipecalculator.ui.foodstuffslist.ListOfFoodstuffsActivity;
 
 public abstract class BaseActivity extends AppCompatActivity {
+    private ActivityInjector injector = new DefaultActivityInjector();
     private Drawer drawer;
+    private boolean onCreateCalled;
+
+    /**
+     * Метод требуется для подмены Даггера в тестах.
+     */
+    public void setInjector(
+            ActivityInjector<? extends BaseActivity> injector) {
+        if (onCreateCalled) {
+            throw new IllegalStateException("Must be called before onCreate");
+        }
+        this.injector = injector;
+    }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected void onCreate(Bundle savedInstanceState) {
-        AndroidInjection.inject(this);
+        onCreateCalled = true;
+        injector.inject(this);
         super.onCreate(savedInstanceState);
     }
 

--- a/app/src/main/java/korablique/recipecalculator/dagger/ActivityInjector.java
+++ b/app/src/main/java/korablique/recipecalculator/dagger/ActivityInjector.java
@@ -1,0 +1,11 @@
+package korablique.recipecalculator.dagger;
+
+import korablique.recipecalculator.base.BaseActivity;
+
+/**
+ * Интерфейс для осуществления инъекций в Активити.
+ * Нужен для подмены Даггера в тестах.
+ */
+public interface ActivityInjector<T extends BaseActivity> {
+    void inject(T activity);
+}

--- a/app/src/main/java/korablique/recipecalculator/dagger/DefaultActivityInjector.java
+++ b/app/src/main/java/korablique/recipecalculator/dagger/DefaultActivityInjector.java
@@ -1,0 +1,14 @@
+package korablique.recipecalculator.dagger;
+
+import dagger.android.AndroidInjection;
+import korablique.recipecalculator.base.BaseActivity;
+
+/**
+ * Реализует инъекции в Активити посредством Даггера.
+ */
+public class DefaultActivityInjector<T extends BaseActivity> implements ActivityInjector<T> {
+    @Override
+    public void inject(T activity) {
+        AndroidInjection.inject(activity);
+    }
+}

--- a/app/src/main/java/korablique/recipecalculator/ui/calculator/CalculatorActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/calculator/CalculatorActivity.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 
 import javax.inject.Inject;
 
-import io.fabric.sdk.android.Fabric;
 import korablique.recipecalculator.ui.Card;
 import korablique.recipecalculator.ui.CardDisplaySource;
 import korablique.recipecalculator.database.DatabaseWorker;
@@ -27,7 +26,7 @@ import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.ui.FoodstuffsAdapter;
 import korablique.recipecalculator.ui.KeyboardHandler;
 import korablique.recipecalculator.ui.foodstuffslist.ListOfFoodstuffsActivity;
-import korablique.recipecalculator.ui.BaseActivity;
+import korablique.recipecalculator.base.BaseActivity;
 import korablique.recipecalculator.R;
 import korablique.recipecalculator.ui.RecyclerViewUtils;
 

--- a/app/src/main/java/korablique/recipecalculator/ui/foodstuffslist/ListOfFoodstuffsActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/foodstuffslist/ListOfFoodstuffsActivity.java
@@ -5,14 +5,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
-import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.ViewGroup;
 import android.widget.EditText;
 
@@ -28,7 +26,7 @@ import korablique.recipecalculator.database.DatabaseWorker;
 import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.ui.FoodstuffsAdapter;
 import korablique.recipecalculator.ui.KeyboardHandler;
-import korablique.recipecalculator.ui.BaseActivity;
+import korablique.recipecalculator.base.BaseActivity;
 import korablique.recipecalculator.R;
 
 import static korablique.recipecalculator.IntentConstants.NAME;
@@ -203,20 +201,5 @@ public class ListOfFoodstuffsActivity extends BaseActivity {
         } else {
             Crashlytics.log("getSupportActionBar вернул null");
         }
-    }
-
-    //метод для тестов
-    public void reload() {
-        for (int index = recyclerViewAdapter.getItemCount() - 1; index >= 0; index--) {
-            recyclerViewAdapter.deleteItem(index);
-        }
-        databaseWorker.requestListedFoodstuffsFromDb(this, new DatabaseWorker.FoodstuffsRequestCallback() {
-            @Override
-            public void onResult(final ArrayList<Foodstuff> foodstuffs) {
-                for (Foodstuff foodstuff : foodstuffs) {
-                    recyclerViewAdapter.addItem(foodstuff);
-                }
-            }
-        });
     }
 }

--- a/app/src/main/java/korablique/recipecalculator/ui/history/HistoryActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/history/HistoryActivity.java
@@ -25,7 +25,7 @@ import korablique.recipecalculator.database.DatabaseWorker;
 import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.ui.KeyboardHandler;
 import korablique.recipecalculator.ui.foodstuffslist.ListOfFoodstuffsActivity;
-import korablique.recipecalculator.ui.BaseActivity;
+import korablique.recipecalculator.base.BaseActivity;
 import korablique.recipecalculator.R;
 import korablique.recipecalculator.model.RateCalculator;
 import korablique.recipecalculator.model.Rates;

--- a/app/src/main/java/korablique/recipecalculator/ui/usergoal/UserGoalActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/usergoal/UserGoalActivity.java
@@ -15,7 +15,7 @@ import com.crashlytics.android.Crashlytics;
 import javax.inject.Inject;
 
 import korablique.recipecalculator.database.DatabaseWorker;
-import korablique.recipecalculator.ui.BaseActivity;
+import korablique.recipecalculator.base.BaseActivity;
 import korablique.recipecalculator.R;
 import korablique.recipecalculator.model.UserParameters;
 import korablique.recipecalculator.ui.history.HistoryActivity;


### PR DESCRIPTION
Основное изменение - добавление возможности "подменять" Даггер в тестах, чтобы осуществлять инъекцию в Активити вручную.
Когда добавлял Даггер, допустил ошибку - инициилизировал @Inject-поля Активити в тестах в @Before, хотя некоторые Активити к этому моменту уже успевали получить от Даггера настоящие объекты и заиспользовать их (например, HistoryActivity в своём onCreate сразу проверяет параметры юзера в БД). В результате создавалось состояние гонки.

Второе важное изменение - создание и использование `SyncMainThreadExecutor` в тестах Активити вместо `InstantMainThreadExecutor`.
`InstantMainThreadExecutor` делает вид, что тот поток, в котором его дёрнули, и есть главный, что противоречило тому, что думают Активити - они внутри себя делают `runOnUiThread` (в т.ч. неявно, например через `RecyclerView`), в результате главных потока получается как бы 2 - один поток тестов (из-за `InstantMainThreadExecutor`), и второй настоящий UI-поток - из-за этого возникали состояния гонки и время от времени элементы UI это понимали и крешили тесты.