### PR TITLE
Исправление креша в HistoryWorker

### DIFF
--- a/app/src/androidTest/java/korablique/recipecalculator/ui/mainscreen/MainActivityTest.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/mainscreen/MainActivityTest.java
@@ -974,7 +974,7 @@ public class MainActivityTest {
 
     private List<Foodstuff> extractFoodstuffsTopFromDB() {
         List<Foodstuff> listedFoodstuffs = new ArrayList<>();
-        historyWorker.requestListedFoodstuffsFromHistoryForPeroid(0, Long.MAX_VALUE, listedFoodstuffs::addAll);
+        historyWorker.requestListedFoodstuffsFromHistoryForPeriod(0, Long.MAX_VALUE, listedFoodstuffs::addAll);
 
         List<PopularProductsUtils.FoodstuffFrequency> foodstuffFrequencies = PopularProductsUtils.getTop(listedFoodstuffs);
         List<Foodstuff> top = new ArrayList<>();

--- a/app/src/main/java/korablique/recipecalculator/database/HistoryWorker.java
+++ b/app/src/main/java/korablique/recipecalculator/database/HistoryWorker.java
@@ -264,7 +264,7 @@ public class HistoryWorker {
         });
     }
 
-    public void requestListedFoodstuffsFromHistoryForPeroid(
+    public void requestListedFoodstuffsFromHistoryForPeriod(
             final long from,
             final long to,
             @NonNull Callback<List<Foodstuff>> callback) {
@@ -284,7 +284,7 @@ public class HistoryWorker {
                 Foodstuff foodstuff = Foodstuff.withId(id).withName(name).withNutrition(protein, fats, carbs, calories);
                 listedFoodstuffs.add(foodstuff);
             }
-            callback.onResult(listedFoodstuffs);
+            mainThreadExecutor.execute(() -> callback.onResult(listedFoodstuffs));
         });
     }
 

--- a/app/src/main/java/korablique/recipecalculator/model/TopList.java
+++ b/app/src/main/java/korablique/recipecalculator/model/TopList.java
@@ -33,7 +33,7 @@ public class TopList {
         // а затем уже добавляем в адаптеры элементы.
         // Это нужно для того, чтобы элементы на экране загружались все сразу
         List<Foodstuff> foodstuffs = new ArrayList<>(); // это продукты за период
-        historyWorker.requestListedFoodstuffsFromHistoryForPeroid(
+        historyWorker.requestListedFoodstuffsFromHistoryForPeriod(
                 0,
                 Long.MAX_VALUE,
                 (listedFoodstuffs) -> {


### PR DESCRIPTION
Колбек вызывался из фоновго (БД) потока, а клиент метода, передавший колбек, ожидал вызова с главного потока - иногда клиент детонировал.