### PR TITLE
Временно отключаем напоминалки о приемах пищи

### DIFF
--- a/app/src/main/java/korablique/recipecalculator/BroccalcApplication.java
+++ b/app/src/main/java/korablique/recipecalculator/BroccalcApplication.java
@@ -39,7 +39,8 @@ public class BroccalcApplication extends Application implements HasActivityInjec
             InjectorHolder.getInjector().inject(this);
             historyWorker.initCache();
             userParametersWorker.initCache();
-            foodReminder.scheduleNotification();
+            // TODO: Вернуть шедулинг нотификаций после доработки логики их показа
+//            foodReminder.scheduleNotification();
         }
     }
 


### PR DESCRIPTION
Временно отключаем напоминалки о приемах пищи - нужно доработать их логику чтобы она 100% не анноила пользователя, делать это нужно не в первом релизе.