### PR TITLE
Очищаем поисковую строку при возврате из экрана поиска

### DIFF
--- a/app/src/main/java/korablique/recipecalculator/base/BaseActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/base/BaseActivity.java
@@ -65,8 +65,8 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
         activityCallbacks.dispatchActivityBackPressed();
+        super.onBackPressed();
     }
 
     @Override

--- a/app/src/main/java/korablique/recipecalculator/ui/mainscreen/MainScreenController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainscreen/MainScreenController.java
@@ -351,6 +351,8 @@ public class MainScreenController extends FragmentCallbacks.Observer implements 
             }
             if (!searchQueries.empty()) {
                 searchView.setSearchText(searchQueries.peek());
+            } else {
+                searchView.clearQuery();
             }
         } else {
             searchQueries.clear();


### PR DESCRIPTION
Очищаем поисковую строку при возврате из экрана поиска.
https://trello.com/c/K0vv7vmz

Основное изменение - сперва диспатчим `dispatchActivityBackPressed` до слушателей, потом только в супера. Это нужно для того, чтобы при нажатии на бэк в последнем (т.е. первом) экране поиска `MainScreenController.java` в своём `onActivityBackPressed` сделав вызов `context.getSupportFragmentManager().findFragmentByTag` нашёл бы этот последний экран истории и имел бы возможность очистить строку поиска, прежде чем экран истории закроется из-за передачи вызова суперу.