### PR TITLE
Ограничиваем длину имени, отображаемого в Профиле

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -32,12 +32,15 @@
             <TextView
                 android:id="@+id/user_name"
                 style="@style/MontserratBigWhiteText"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginStart="16dp"
+                android:ellipsize="end"
+                android:maxLines="2"
                 app:layout_constraintStart_toEndOf="@+id/imageView"
                 app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/layout_button_edit"
                 tools:text="Лилия Панова" />
 
             <include


### PR DESCRIPTION
Ограничиваем длину имени, отображаемого в Профиле.
https://trello.com/c/XivZ6PH2

До:
![image](https://user-images.githubusercontent.com/3338378/60753752-38720d00-9fe0-11e9-813f-2d6cb0a67ad0.png)

После:
![image](https://user-images.githubusercontent.com/3338378/60753754-3dcf5780-9fe0-11e9-831c-06e2d40c09be.png)

Эффект на лицо!