### PR TITLE
Исправлен креш, вызванный запуском MainActivity из Application-контекста

### DIFF
--- a/app/src/androidTest/java/korablique/recipecalculator/test/FakeTestActivity.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/test/FakeTestActivity.java
@@ -1,0 +1,14 @@
+package korablique.recipecalculator.test;
+
+import korablique.recipecalculator.base.BaseActivity;
+
+/**
+ * Fake test Activity class for tests which need an Activity to perform some actions
+ * (for example, often an Activity is required to start another Activity).
+ */
+public class FakeTestActivity extends BaseActivity {
+    @Override
+    protected Integer getLayoutId() {
+        return null;
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainScreenLoaderTest.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainScreenLoaderTest.java
@@ -6,29 +6,31 @@ import android.content.Intent;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import korablique.recipecalculator.base.Callback;
 import korablique.recipecalculator.base.CurrentActivityProvider;
-import korablique.recipecalculator.dagger.Injector;
 import korablique.recipecalculator.dagger.InjectorHolder;
 import korablique.recipecalculator.database.FoodstuffsList;
 import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.model.FoodstuffsTopList;
 import korablique.recipecalculator.model.Nutrition;
+import korablique.recipecalculator.test.FakeTestActivity;
+import korablique.recipecalculator.util.InjectableActivityTestRule;
 import korablique.recipecalculator.util.TestingInjector;
 
 import static androidx.test.espresso.intent.Intents.intended;
@@ -45,6 +47,10 @@ import static org.mockito.Mockito.mock;
 public class MainScreenLoaderTest {
     private Context context;
     private TestingInjector injector;
+
+    @Rule
+    public ActivityTestRule<FakeTestActivity> fakeActivityTestRule =
+            new ActivityTestRule<>(FakeTestActivity.class, false, false /* launch activity */);
 
     @Mock
     private FoodstuffsList foodstuffsList;
@@ -72,6 +78,8 @@ public class MainScreenLoaderTest {
                 InstrumentationRegistry.getInstrumentation().getTargetContext(),
                 foodstuffsList,
                 foodstuffsTopList);
+
+        fakeActivityTestRule.launchActivity(null);
     }
 
     @After
@@ -134,7 +142,7 @@ public class MainScreenLoaderTest {
 
         // Load main screen activity and verify that a start intent was sent
         // (with expected bundle inside).
-        mainScreenLoader.loadMainScreenActivity().subscribe();
+        mainScreenLoader.loadMainScreenActivity(fakeActivityTestRule.getActivity()).subscribe();
         intended(allOf(
                 hasAction(expectedIntent.getAction()),
                 hasExtras(hasValueRecursive(expectedIntent.getExtras()))));

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="korablique.recipecalculator">
+
+    <application>
+        <activity
+            android:name=".test.FakeTestActivity">
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivity.java
@@ -1,5 +1,6 @@
 package korablique.recipecalculator.ui.mainactivity;
 
+import android.app.Activity;
 import android.content.Context;
 
 import androidx.fragment.app.Fragment;
@@ -36,8 +37,8 @@ public class MainActivity extends BaseActivity implements HasSupportFragmentInje
     }
 
     public static void openMainScreen(
-            Context context, ArrayList<Foodstuff> top, ArrayList<Foodstuff> allFoodstuffsFirstBatch) {
-        MainActivityController.openMainScreen(context, top, allFoodstuffsFirstBatch);
+            Activity parent, ArrayList<Foodstuff> top, ArrayList<Foodstuff> allFoodstuffsFirstBatch) {
+        MainActivityController.openMainScreen(parent, top, allFoodstuffsFirstBatch);
     }
 
     public static void openHistoryAndAddFoodstuffs(

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivityController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivityController.java
@@ -1,5 +1,6 @@
 package korablique.recipecalculator.ui.mainactivity;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -73,8 +74,8 @@ public class MainActivityController implements ActivityCallbacks.Observer {
     }
 
     public static void openMainScreen(
-            Context context, ArrayList<Foodstuff> top, ArrayList<Foodstuff> allFoodstuffsFirstBatch) {
-        context.startActivity(createMainScreenIntent(context, top, allFoodstuffsFirstBatch));
+            Activity parent, ArrayList<Foodstuff> top, ArrayList<Foodstuff> allFoodstuffsFirstBatch) {
+        parent.startActivity(createMainScreenIntent(parent, top, allFoodstuffsFirstBatch));
     }
 
     public static Intent createMainScreenIntent(

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainScreenLoader.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainScreenLoader.java
@@ -1,5 +1,6 @@
 package korablique.recipecalculator.ui.mainactivity;
 
+import android.app.Activity;
 import android.content.Context;
 import android.util.Pair;
 
@@ -32,7 +33,7 @@ public class MainScreenLoader {
         this.topList = topList;
     }
 
-    public Completable loadMainScreenActivity() {
+    public Completable loadMainScreenActivity(Activity parent) {
         Single<List<Foodstuff>> topSingle = Single.create((emitter -> {
             topList.getTopList(emitter::onSuccess);
         }));
@@ -67,7 +68,7 @@ public class MainScreenLoader {
         return Single.zip(topSingle, allFoodstuffsFirstBatch, Pair::create)
                 .map((topAndFirstBatch) -> {
                     MainActivity.openMainScreen(
-                            context,
+                            parent,
                             new ArrayList<>(topAndFirstBatch.first),
                             new ArrayList<>(topAndFirstBatch.second));
                     return 1;

--- a/app/src/main/java/korablique/recipecalculator/ui/splash/SplashScreenActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/splash/SplashScreenActivity.java
@@ -30,7 +30,7 @@ public class SplashScreenActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         rxSubscriptions.subscribe(userParametersWorker.requestCurrentUserParameters(), (params) -> {
             if (params.isPresent()) {
-                rxSubscriptions.subscribe(mainScreenLoader.loadMainScreenActivity());
+                rxSubscriptions.subscribe(mainScreenLoader.loadMainScreenActivity(this));
             } else {
                 UserParametersActivity.start(this);
             }

--- a/app/src/main/java/korablique/recipecalculator/ui/userparameters/UserParametersActivity.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/userparameters/UserParametersActivity.java
@@ -109,7 +109,7 @@ public class UserParametersActivity extends BaseActivity {
                         // Закажем загрузку MainActivity и подпишемся на окончание загрузки,
                         // при окончании загрузки завершим себя (finish()).
                         subscriptions.subscribe(
-                                mainScreenLoader.loadMainScreenActivity(),
+                                mainScreenLoader.loadMainScreenActivity(UserParametersActivity.this),
                                 UserParametersActivity.this::finish);
                     } else {
                         finish();


### PR DESCRIPTION
Оказывается, делать `((Context)Application).startActivity(...)` - не очень законно, приложение падает с:
```
Calling startActivity() from outside of an Activity  context requires the  
FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
```
(https://stackoverflow.com/questions/3918517/calling-startactivity-from-outside-of-an-activity-context)
Убираем такой запуск `MainActivity` из `MainScreenLoader`.

Также, чтобы работал тест `MainScreenLoaderTest`, который грузит мейн активити черз `MainScreenLoader`, добавил новую пустую активити `FakeTestActivity` в дебажный режим приложения (для этого добавлен новый AndroidMainfest) - иначе у `MainScreenLoaderTest` нет активить, а `MainScreenLoader` теперь требует parent-Активити, которая будет родителем мейн скрина.