### PR TITLE
Попытка исправить креш при смене сессии

### DIFF
--- a/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityTestsBase.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityTestsBase.java
@@ -115,7 +115,7 @@ public class MainActivityTestsBase {
                         mainActivitySelectedDateStorage = new MainActivitySelectedDateStorage(
                                 activity, activityCallbacks, sessionController, timeProvider);
                         fragmentsController = new MainActivityFragmentsController(
-                                activity, sessionController, activityCallbacks);
+                                activity, sessionController, currentActivityProvider, activityCallbacks);
                         MainActivityController controller = new MainActivityController(
                                 activity, activityCallbacks, fragmentsController);
                         return Collections.singletonList(controller);

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivityFragmentsController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/MainActivityFragmentsController.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import korablique.recipecalculator.R;
 import korablique.recipecalculator.base.ActivityCallbacks;
+import korablique.recipecalculator.base.CurrentActivityProvider;
 import korablique.recipecalculator.dagger.ActivityScope;
 import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.model.WeightedFoodstuff;
@@ -36,6 +37,7 @@ public class MainActivityFragmentsController implements
     private static final String EXTRA_MAIN_SCREEN_ARGUMENTS = "EXTRA_MAIN_SCREEN_ARGUMENTS";
     private final MainActivity mainActivity;
     private final SessionController sessionController;
+    private final CurrentActivityProvider currentActivityProvider;
     private final List<Observer> observers = new ArrayList<>();
 
     private BottomNavigationView bottomNavigationView;
@@ -53,9 +55,11 @@ public class MainActivityFragmentsController implements
     public MainActivityFragmentsController(
             MainActivity mainActivity,
             SessionController sessionController,
+            CurrentActivityProvider currentActivityProvider,
             ActivityCallbacks activityCallbacks) {
         this.mainActivity = mainActivity;
         this.sessionController = sessionController;
+        this.currentActivityProvider = currentActivityProvider;
         activityCallbacks.addObserver(this);
         sessionController.addObserver(this);
     }
@@ -176,6 +180,10 @@ public class MainActivityFragmentsController implements
 
     @Override
     public void onNewSession() {
+        if (mainActivity != currentActivityProvider.getCurrentActivity()) {
+            // Началась какая-то другая сессия, к нам не относящаяся.
+            return;
+        }
         // В начале новой сессии меняем активный фрагмент на MainScreen
         bottomNavigationView.setSelectedItemId(R.id.menu_item_foodstuffs);
         sessionController.onClientStartedNewSession(SessionClient.MAIN_ACTIVITY_FRAGMENT);


### PR DESCRIPTION
Попытка исправить креш при смене сессии.
Креш: https://fabric.io/korablique/android/apps/korablique.recipecalculator/issues/001e43a10878439bba9690d5320a8f04

Полный стек:
```
Fatal Exception: java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
       at androidx.fragment.app.FragmentManagerImpl.checkStateLoss + 1536(FragmentManagerImpl.java:1536)
       at androidx.fragment.app.FragmentManagerImpl.enqueueAction + 1558(FragmentManagerImpl.java:1558)
       at androidx.fragment.app.BackStackRecord.commitInternal + 317(BackStackRecord.java:317)
       at androidx.fragment.app.BackStackRecord.commit + 282(BackStackRecord.java:282)
       at korablique.recipecalculator.ui.mainactivity.MainActivityFragmentsController.switchToFragment + 134(MainActivityFragmentsController.java:134)
       at korablique.recipecalculator.ui.mainactivity.MainActivityFragmentsController.lambda$onActivityCreate$0$MainActivityFragmentsController + 109(MainActivityFragmentsController.java:109)
       at korablique.recipecalculator.ui.mainactivity.-$$Lambda$MainActivityFragmentsController$CvLuWW1cWTKQTISExozPhnMw50s.onNavigationItemSelected + 2(:2)
       at com.google.android.material.bottomnavigation.BottomNavigationView$1.onMenuItemSelected + 238(BottomNavigationView.java:238)
       at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected + 840(MenuBuilder.java:840)
       at androidx.appcompat.view.menu.MenuItemImpl.invoke + 158(MenuItemImpl.java:158)
       at androidx.appcompat.view.menu.MenuBuilder.performItemAction + 991(MenuBuilder.java:991)
       at com.google.android.material.bottomnavigation.BottomNavigationView.setSelectedItemId + 520(BottomNavigationView.java:520)
       at korablique.recipecalculator.ui.mainactivity.MainActivityFragmentsController.onNewSession + 175(MainActivityFragmentsController.java:175)
       at korablique.recipecalculator.session.SessionController.onCurrentActivityChanged + 102(SessionController.java:102)
       at korablique.recipecalculator.base.CurrentActivityProvider.onActivityStart + 58(CurrentActivityProvider.java:58)
       at korablique.recipecalculator.base.CurrentActivityProvider.access$000 + 26(CurrentActivityProvider.java:26)
       at korablique.recipecalculator.base.CurrentActivityProvider$ActivityWatcher.onActivityStart + 92(CurrentActivityProvider.java:92)
       at korablique.recipecalculator.base.ActivityCallbacks.dispatchActivityStart + 51(ActivityCallbacks.java:51)
       at korablique.recipecalculator.base.BaseActivity.onStart + 61(BaseActivity.java:61)
       at android.app.Instrumentation.callActivityOnStart + 1392(Instrumentation.java:1392)
       at android.app.Activity.performStart + 7165(Activity.java:7165)
       at android.app.ActivityThread.handleStartActivity + 2976(ActivityThread.java:2976)
       at android.app.servertransaction.TransactionExecutor.performLifecycleSequence + 180(TransactionExecutor.java:180)
       at android.app.servertransaction.TransactionExecutor.cycleToPath + 165(TransactionExecutor.java:165)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState + 142(TransactionExecutor.java:142)
       at android.app.servertransaction.TransactionExecutor.execute + 70(TransactionExecutor.java:70)
       at android.app.ActivityThread$H.handleMessage + 1817(ActivityThread.java:1817)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 193(Looper.java:193)
       at android.app.ActivityThread.main + 6746(ActivityThread.java:6746)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 858(ZygoteInit.java:858)
```