### PR TITLE
Исправляем longtap у бекспейса на CalcKeyboard

### DIFF
--- a/app/src/main/java/korablique/recipecalculator/ui/calckeyboard/CalcKeyboard.kt
+++ b/app/src/main/java/korablique/recipecalculator/ui/calckeyboard/CalcKeyboard.kt
@@ -124,7 +124,7 @@ class CalcKeyboard : LinearLayout {
             return
         }
         // Бэкспейс держат в течение INTERVAL_BETWEEN_BACKSPACE_HOLD_DELETIONS, удалим символ
-        performTextDeletion(inputConnection)
+        onButtonClick(findViewById<View>(R.id.button_backspace))
 
         // Если бекспейс ещё нажат, через несколько мс снова удалим символ!
         if (isBackspaseBeingHeld) {


### PR DESCRIPTION
Исправляем longtap у бекспейса на CalcKeyboard (https://trello.com/c/etAm71CT)

Проблема была в отсутствии вызова `inputConnection.finishComposingText()`, в качестве исправления вместо прямого удаления текста по тику лонгтапа делаем вид, что был нажан бекспейс.