### PR TITLE
Исправлено скругление plural progressbar'а в карточке

### DIFF
--- a/app/src/main/res/layout/card_layout.xml
+++ b/app/src/main/res/layout/card_layout.xml
@@ -84,15 +84,20 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <include
-            android:id="@+id/nutrition_progress_with_values"
-            layout="@layout/nutrition_progress_with_values"
+        <FrameLayout
+            android:id="@+id/nutrition_progress_with_values_parent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="15dp"
-            android:layout_marginEnd="15dp"
+            android:paddingStart="15dp"
+            android:paddingEnd="15dp"
             android:layout_marginTop="14dp"
-            app:layout_constraintTop_toBottomOf="@+id/foodstuff_name_text_view" />
+            app:layout_constraintTop_toBottomOf="@+id/foodstuff_name_text_view">
+            <include
+                android:id="@+id/nutrition_progress_with_values"
+                layout="@layout/nutrition_progress_with_values"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </FrameLayout>
 
         <View
             android:id="@+id/row_fake_top"
@@ -100,7 +105,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="24dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/nutrition_progress_with_values" />
+            app:layout_constraintTop_toBottomOf="@id/nutrition_progress_with_values_parent" />
 
         <TextView
             android:id="@+id/weight_text_view"
@@ -110,7 +115,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginStart="15dp"
             android:layout_marginEnd="15dp"
-            app:layout_constraintTop_toBottomOf="@id/nutrition_progress_with_values"
+            app:layout_constraintTop_toBottomOf="@id/nutrition_progress_with_values_parent"
             app:layout_constraintStart_toStartOf="parent"
             android:text="@string/weight_in_card" />
 


### PR DESCRIPTION
Исправлено скругление plural progressbar'а в карточке (https://trello.com/c/JtJSJY0Q)

Похоже, если у `include` делать сложные параметры (маржины по бокам, например), то вставляемую разметку может начать карёжить.

В нашем случае у плюрал прогрессбара обрезалась правая часть при отрисовке, в результате справа он не выглядил скруглённым.

Решил проблемы вставкой `include` в родительский frame layout.