### PR TITLE
Переработка BucketList'а, исправление бага неизменения массы продукта в bucket list'е

### DIFF
--- a/app/src/androidTest/java/korablique/recipecalculator/base/prefs/PrefsCleaningHelper.kt
+++ b/app/src/androidTest/java/korablique/recipecalculator/base/prefs/PrefsCleaningHelper.kt
@@ -1,0 +1,15 @@
+package korablique.recipecalculator.base.prefs
+
+import android.app.Activity
+import android.content.Context
+
+object PrefsCleaningHelper {
+    fun cleanAllPrefs(context: Context) {
+        PrefsOwner.values().forEach {
+            context.getSharedPreferences(it.fileName, Activity.MODE_PRIVATE)
+                    .edit()
+                    .clear()
+                    .commit()
+        }
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/base/prefs/SharedPrefsManagerTest.kt
+++ b/app/src/androidTest/java/korablique/recipecalculator/base/prefs/SharedPrefsManagerTest.kt
@@ -1,0 +1,80 @@
+package korablique.recipecalculator.base.prefs
+
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import korablique.recipecalculator.util.FloatUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class SharedPrefsManagerTest {
+    lateinit var prefsManager: SharedPrefsManager
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        PrefsCleaningHelper.cleanAllPrefs(context)
+        prefsManager = SharedPrefsManager(context)
+    }
+
+    @Test
+    fun canPutAndGetLongsList() {
+        val myKey = "myKey"
+        var extractedLongList = prefsManager.getLongList(PrefsOwner.BUCKET_LIST, myKey)
+        assertEquals(null, extractedLongList)
+
+        val createdLongList = listOf(1L, 2L, 3L)
+        prefsManager.putLongList(PrefsOwner.BUCKET_LIST, myKey, createdLongList)
+
+        extractedLongList = prefsManager.getLongList(PrefsOwner.BUCKET_LIST, myKey)
+        assertEquals(3, extractedLongList!!.size)
+        assertEquals(createdLongList, extractedLongList!!)
+    }
+
+    @Test
+    fun canPutAndGetFloatList() {
+        val myKey = "myKey"
+        var extractedFloatList = prefsManager.getFloatList(PrefsOwner.BUCKET_LIST, myKey)
+        assertEquals(null, extractedFloatList)
+
+        val createdFloatList = listOf(123.123.toFloat(), 321.321.toFloat(), 213.111.toFloat())
+        prefsManager.putFloatList(PrefsOwner.BUCKET_LIST, myKey, createdFloatList, digitsAfterDot = 3)
+
+        extractedFloatList = prefsManager.getFloatList(PrefsOwner.BUCKET_LIST, myKey)
+        assertEquals(3, extractedFloatList!!.size)
+        for (index in extractedFloatList.indices) {
+            assertTrue(FloatUtils.areFloatsEquals(extractedFloatList[index], createdFloatList[index]))
+        }
+    }
+
+    @Test
+    fun canChooseStoredFloatsPrecision() {
+        val myKey = "myKey"
+        val precision = 2.toShort()
+        val createdFloatList = listOf(123.1234.toFloat(), 321.3210.toFloat(), 213.1111.toFloat())
+        prefsManager.putFloatList(PrefsOwner.BUCKET_LIST, myKey, createdFloatList, digitsAfterDot = precision)
+
+        val extractedFloatList = prefsManager.getFloatList(PrefsOwner.BUCKET_LIST, myKey)
+        val floatsAsStrs = extractedFloatList!!.map { it.toString() }
+        assertEquals("123.12", floatsAsStrs[0])
+        assertEquals("321.32", floatsAsStrs[1])
+        assertEquals("213.11", floatsAsStrs[2])
+    }
+
+    @Test
+    fun canPutAndGetEmptyFloatList() {
+        prefsManager.putFloatList(PrefsOwner.BUCKET_LIST, "mykey", emptyList(), digitsAfterDot = 3)
+        assertEquals(null, prefsManager.getFloatList(PrefsOwner.BUCKET_LIST, "mykey"))
+    }
+
+    @Test
+    fun canPutAndGetEmptyLongList() {
+        prefsManager.putLongList(PrefsOwner.BUCKET_LIST, "mykey", emptyList())
+        assertEquals(null, prefsManager.getLongList(PrefsOwner.BUCKET_LIST, "mykey"))
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/ui/bucketlist/BucketListTest.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/bucketlist/BucketListTest.java
@@ -1,0 +1,142 @@
+package korablique.recipecalculator.ui.bucketlist;
+
+import android.content.Context;
+
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import korablique.recipecalculator.base.executors.ComputationThreadsExecutor;
+import korablique.recipecalculator.base.executors.MainThreadExecutor;
+import korablique.recipecalculator.base.prefs.PrefsCleaningHelper;
+import korablique.recipecalculator.base.prefs.SharedPrefsManager;
+import korablique.recipecalculator.database.DatabaseThreadExecutor;
+import korablique.recipecalculator.database.DatabaseWorker;
+import korablique.recipecalculator.database.FoodstuffsList;
+import korablique.recipecalculator.database.room.DatabaseHolder;
+import korablique.recipecalculator.model.Foodstuff;
+import korablique.recipecalculator.model.WeightedFoodstuff;
+import korablique.recipecalculator.util.InstantComputationsThreadsExecutor;
+import korablique.recipecalculator.util.InstantDatabaseThreadExecutor;
+import korablique.recipecalculator.util.SyncMainThreadExecutor;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class BucketListTest {
+    private Context context;
+    MainThreadExecutor mainThreadExecutor;
+    private SharedPrefsManager prefsManager;
+    private FoodstuffsList foodstuffsList;
+    private BucketList bucketList;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        PrefsCleaningHelper.INSTANCE.cleanAllPrefs(context);
+
+        mainThreadExecutor = new SyncMainThreadExecutor();
+        DatabaseThreadExecutor databaseThreadExecutor = new InstantDatabaseThreadExecutor();
+        DatabaseHolder databaseHolder = new DatabaseHolder(context, databaseThreadExecutor);
+        DatabaseWorker databaseWorker = new DatabaseWorker(databaseHolder, mainThreadExecutor, databaseThreadExecutor);
+        databaseHolder.getDatabase().clearAllTables();
+
+        ComputationThreadsExecutor computationThreadsExecutor = new InstantComputationsThreadsExecutor();
+
+        prefsManager = new SharedPrefsManager(context);
+        foodstuffsList =
+                new FoodstuffsList(
+                        databaseWorker,
+                        mainThreadExecutor,
+                        computationThreadsExecutor);
+        bucketList = new BucketList(prefsManager, foodstuffsList);
+    }
+
+    @Test
+    public void bucketListRestoresFromPrefs() {
+        Foodstuff savedFoodstuff =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("apple").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+
+        WeightedFoodstuff wf = savedFoodstuff.withWeight(123);
+        bucketList.add(wf);
+
+        // Новый бакетлист со старым prefs manager'ом
+        BucketList bucketList2 = new BucketList(prefsManager, foodstuffsList);
+        Assert.assertEquals(Collections.singletonList(wf), bucketList2.getList());
+    }
+
+    @Test
+    public void bucketListCannotRestoreFromEmptyPrefs() {
+        Foodstuff savedFoodstuff =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("apple").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+
+        WeightedFoodstuff wf = savedFoodstuff.withWeight(123);
+        bucketList.add(wf);
+
+        // Чистим преференсы!
+        PrefsCleaningHelper.INSTANCE.cleanAllPrefs(context);
+
+        // Новый бакетлист со старым prefs manager'ом, но преференсы очищены
+        BucketList bucketList2 = new BucketList(prefsManager, foodstuffsList);
+        Assert.assertEquals(Collections.emptyList(), bucketList2.getList());
+    }
+
+    @Test
+    public void bucketListRestoresAsEmpty_ifFoodstuffRemoved() {
+        Foodstuff savedFoodstuff1 =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("apple").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+        Foodstuff savedFoodstuff2 =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("carrot").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+
+        WeightedFoodstuff wf1 = savedFoodstuff1.withWeight(123);
+        WeightedFoodstuff wf2 = savedFoodstuff2.withWeight(123);
+        bucketList.add(wf1);
+        bucketList.add(wf2);
+
+        // Удаляем продукт!
+        bucketList.remove(wf1);
+
+        // Новый бакетлист со старым prefs manager'ом
+        BucketList bucketList2 = new BucketList(prefsManager, foodstuffsList);
+        Assert.assertEquals(Collections.singletonList(wf2), bucketList2.getList());
+    }
+
+    @Test
+    public void bucketListRestoresAsEmpty_ifFoodstuffsCleared() {
+        Foodstuff savedFoodstuff1 =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("apple").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+        Foodstuff savedFoodstuff2 =
+                foodstuffsList
+                        .saveFoodstuff(Foodstuff.withName("carrot").withNutrition(1, 2, 3, 4))
+                        .blockingGet();
+
+        WeightedFoodstuff wf1 = savedFoodstuff1.withWeight(123);
+        WeightedFoodstuff wf2 = savedFoodstuff2.withWeight(123);
+        bucketList.add(wf1);
+        bucketList.add(wf2);
+
+        // Удаляем все продукты!
+        bucketList.clear();
+
+        // Новый бакетлист со старым prefs manager'ом
+        BucketList bucketList2 = new BucketList(prefsManager, foodstuffsList);
+        Assert.assertEquals(Collections.emptyList(), bucketList2.getList());
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityMainScreenSnackbarTest.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityMainScreenSnackbarTest.java
@@ -1,0 +1,121 @@
+package korablique.recipecalculator.ui.mainactivity;
+
+import android.app.Instrumentation;
+
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import korablique.recipecalculator.R;
+import korablique.recipecalculator.model.WeightedFoodstuff;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.swipeRight;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class MainActivityMainScreenSnackbarTest extends MainActivityTestsBase {
+    @Test
+    public void snackbarUpdatesAfterChangingBucketList() {
+        // добавляем в bucket list продукты, запускаем активити, в снекбаре должно быть 3 фудстаффа
+        WeightedFoodstuff wf0 = foodstuffs[0].withWeight(100);
+        WeightedFoodstuff wf1 = foodstuffs[1].withWeight(100);
+        WeightedFoodstuff wf2 = foodstuffs[2].withWeight(100);
+
+        mainThreadExecutor.execute(() -> {
+            bucketList.add(wf0);
+            bucketList.add(wf1);
+            bucketList.add(wf2);
+        });
+
+        mActivityRule.launchActivity(null);
+        onView(withId(R.id.selected_foodstuffs_counter)).check(matches(withText("3")));
+
+        // убираем один продукт, перезапускаем активити, в снекбаре должно быть 2 фудстаффа
+        mainThreadExecutor.execute(() -> {
+            bucketList.remove(foodstuffs[0].withWeight(100));
+        });
+
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        instrumentation.runOnMainSync(() -> mActivityRule.getActivity().recreate());
+        instrumentation.waitForIdleSync();
+        onView(withId(R.id.selected_foodstuffs_counter)).check(matches(isDisplayed()));
+        onView(withId(R.id.selected_foodstuffs_counter)).check(matches(withText("2")));
+        Assert.assertTrue(bucketList.getList().contains(wf1));
+        Assert.assertTrue(bucketList.getList().contains(wf2));
+
+        // убираем все продукты, перезапускаем активити, снекбара быть не должно
+        mainThreadExecutor.execute(() -> {
+            bucketList.clear();
+        });
+        instrumentation.runOnMainSync(() -> mActivityRule.getActivity().recreate());
+        instrumentation.waitForIdleSync();
+        onView(withId(R.id.selected_foodstuffs_counter)).check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void swipedOutSnackbar_cleansBuckerList() throws InterruptedException {
+        // добавляем в bucket list продукты, запускаем активити
+        WeightedFoodstuff wf0 = foodstuffs[0].withWeight(100);
+        WeightedFoodstuff wf1 = foodstuffs[1].withWeight(100);
+
+        mainThreadExecutor.execute(() -> {
+            bucketList.add(wf0);
+            bucketList.add(wf1);
+            assertEquals(2, bucketList.getList().size());
+        });
+
+        mActivityRule.launchActivity(null);
+
+        // "Высвайпываем" снекбар
+        onView(withId(R.id.snackbar)).perform(swipeRight());
+        Thread.sleep(500); // Ждем 0.5с, потому что SwipeDismissBehaviour криво уведомляет о высвайпывании
+
+        // Убеждаемся, что в бакетлисте пусто и снекбар не показан
+        onView(withId(R.id.snackbar)).check(matches(not(isDisplayed())));
+        mainThreadExecutor.execute(() -> {
+            assertTrue(bucketList.getList().isEmpty());
+        });
+    }
+
+    @Test
+    public void swipedOutSnackbar_canBeCanceled() throws InterruptedException {
+        // добавляем в bucket list продукты, запускаем активити
+        WeightedFoodstuff wf0 = foodstuffs[0].withWeight(100);
+        WeightedFoodstuff wf1 = foodstuffs[1].withWeight(100);
+
+        mainThreadExecutor.execute(() -> {
+            bucketList.add(wf0);
+            bucketList.add(wf1);
+            assertEquals(2, bucketList.getList().size());
+        });
+
+        mActivityRule.launchActivity(null);
+
+        // "Высвайпываем" снекбар
+        onView(withId(R.id.snackbar)).perform(swipeRight());
+        Thread.sleep(500); // Ждем 0.5с, потому что SwipeDismissBehaviour криво уведомляет о высвайпывании
+
+        // Тут же отменяем "высвайпывание"
+        onView(withText(R.string.undo)).perform(click());
+
+        // Убеждаемся, что в бакетлисте по-прежнему есть продукты и снекбар показан
+        onView(withId(R.id.snackbar)).check(matches(isDisplayed()));
+        mainThreadExecutor.execute(() -> {
+            assertEquals(2, bucketList.getList().size());
+        });
+    }
+}

--- a/app/src/main/java/korablique/recipecalculator/base/FragmentCallbacks.java
+++ b/app/src/main/java/korablique/recipecalculator/base/FragmentCallbacks.java
@@ -4,11 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class FragmentCallbacks {
-    private final List<Observer> observers = new ArrayList<>();
+    private final List<Observer> observers = new CopyOnWriteArrayList<>();
 
     public interface Observer {
         default void onFragmentCreate(Bundle savedInstanceState) {}

--- a/app/src/main/java/korablique/recipecalculator/base/prefs/PrefsOwner.kt
+++ b/app/src/main/java/korablique/recipecalculator/base/prefs/PrefsOwner.kt
@@ -1,0 +1,5 @@
+package korablique.recipecalculator.base.prefs
+
+enum class PrefsOwner(val fileName: String) {
+    BUCKET_LIST("bucket_list")
+}

--- a/app/src/main/java/korablique/recipecalculator/base/prefs/SharedPrefsManager.kt
+++ b/app/src/main/java/korablique/recipecalculator/base/prefs/SharedPrefsManager.kt
@@ -1,0 +1,50 @@
+package korablique.recipecalculator.base.prefs
+
+import android.content.Context
+import korablique.recipecalculator.ui.DecimalUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val VALS_DELIMETER = ";"
+
+/**
+ * Обёртка над SharedPreferences для более удобного использования их в тестах
+ * и для добавления удобных методов (например, с возможностью сохранять массивы чисел).
+ */
+@Singleton
+class SharedPrefsManager @Inject constructor(val context: Context) {
+    fun putLongList(owner: PrefsOwner, key: String, list: List<Long>) {
+        val strList = list.map { it.toString() }
+        putStringList(owner, key, strList)
+    }
+
+    fun getLongList(owner: PrefsOwner, key: String): List<Long>? {
+        return getStringList(owner, key)?.map { it.toLong() }
+    }
+
+    fun putFloatList(owner: PrefsOwner, key: String, list: List<Float>, digitsAfterDot: Short) {
+        val strList = list.map { DecimalUtils.toDecimalString(it, digitsAfterDot.toInt()) }
+        putStringList(owner, key, strList)
+    }
+
+    fun getFloatList(owner: PrefsOwner, key: String): List<Float>? {
+        return getStringList(owner, key)?.map { it.toFloat() }
+    }
+
+    private fun putStringList(owner: PrefsOwner, key: String, strList: List<String>) {
+        context.getSharedPreferences(owner.fileName, Context.MODE_PRIVATE)
+                .edit()
+                .putString(key, strList.joinToString(separator = VALS_DELIMETER))
+                .apply()
+    }
+
+    private fun getStringList(owner: PrefsOwner, key: String): List<String>? {
+        val str = context
+                .getSharedPreferences(owner.fileName, Context.MODE_PRIVATE)
+                .getString(key, null)
+        if (str == null || str.isEmpty()) {
+            return null
+        }
+        return str.split(VALS_DELIMETER)
+    }
+}

--- a/app/src/main/java/korablique/recipecalculator/model/Foodstuff.java
+++ b/app/src/main/java/korablique/recipecalculator/model/Foodstuff.java
@@ -137,6 +137,10 @@ public class Foodstuff implements Parcelable, Comparable<Foodstuff> {
         return new WeightedFoodstuff(this, weight);
     }
 
+    public Foodstuff recreateWithId(long id) {
+        return Foodstuff.withId(id).withName(name).withNutrition(protein, fats, carbs, calories);
+    }
+
     @Override
     public String toString() {
         return "Foodstuff{" +

--- a/app/src/main/java/korablique/recipecalculator/ui/DecimalUtils.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/DecimalUtils.java
@@ -8,7 +8,24 @@ public class DecimalUtils {
     }
 
     public static String toDecimalString(double decimal) {
-        DecimalFormat df = new DecimalFormat("#.#");
+        return toDecimalString(decimal, 1);
+    }
+
+    public static String toDecimalString(float decimal, int digitsAfterDot) {
+        return toDecimalString((double)decimal, digitsAfterDot);
+    }
+
+    public static String toDecimalString(double decimal, int digitsAfterDot) {
+        if (digitsAfterDot == 0) {
+            return String.valueOf((long)decimal);
+        }
+
+        StringBuilder formatStr = new StringBuilder();
+        formatStr.append("#.");
+        for (int index = 0; index < digitsAfterDot; ++index) {
+            formatStr.append('#');
+        }
+        DecimalFormat df = new DecimalFormat(formatStr.toString());
         String result = df.format(decimal).replace(',', '.');
         if ("-0".equals(result)) {
             return "0";

--- a/app/src/main/java/korablique/recipecalculator/ui/bucketlist/BucketList.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/bucketlist/BucketList.java
@@ -6,40 +6,84 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.reactivex.disposables.Disposable;
+import korablique.recipecalculator.TestEnvironmentDetector;
 import korablique.recipecalculator.WrongThreadException;
+import korablique.recipecalculator.base.prefs.PrefsOwner;
+import korablique.recipecalculator.base.prefs.SharedPrefsManager;
+import korablique.recipecalculator.database.FoodstuffsList;
+import korablique.recipecalculator.model.Foodstuff;
 import korablique.recipecalculator.model.WeightedFoodstuff;
 
+@Singleton
 public class BucketList {
+    private static final String PREFS_FOODSTUFFS_IDS = "PREFS_FOODSTUFFS_IDS";
+    private static final String PREFS_FOODSTUFFS_WEIGHTS = "PREFS_FOODSTUFFS_WEIGHTS";
+    private static final short PERSISTENT_WEIGHT_PRECISION = 3; // 3 цифры после точки хватит всем
     public interface Observer {
         default void onFoodstuffAdded(WeightedFoodstuff wf) {}
         default void onFoodstuffRemoved(WeightedFoodstuff wf) {}
     }
-    private static BucketList instance;
+    private final SharedPrefsManager prefsManager;
     private List<WeightedFoodstuff> bucketList = new ArrayList<>();
     private List<Observer> observers = new ArrayList<>();
 
-    private BucketList() {}
-
-    public static synchronized BucketList getInstance() {
-        if (instance == null) {
-            instance = new BucketList();
+    @Inject
+    public BucketList(
+            SharedPrefsManager prefsManager,
+            FoodstuffsList foodstuffsList) {
+        this.prefsManager = prefsManager;
+        List<Long> ids = prefsManager.getLongList(PrefsOwner.BUCKET_LIST, PREFS_FOODSTUFFS_IDS);
+        List<Float> weights = prefsManager.getFloatList(PrefsOwner.BUCKET_LIST, PREFS_FOODSTUFFS_WEIGHTS);
+        if (ids == null || weights == null) {
+            return;
         }
-        return instance;
+        if (ids.size() != weights.size()) {
+            // TODO: report an error
+            return;
+        }
+        Disposable unusedDisposable =
+                foodstuffsList
+                .getFoodstuffsWithIds(ids)
+                .toList()
+                .subscribe((foodstuffs) -> {
+                    if (foodstuffs.size() != ids.size()) {
+                        // Количество восстановленных продуктов не равно
+                        // количеству запрошенных - что-то пошло не так.
+                        // TODO: report an error
+                        return;
+                    }
+                    List<WeightedFoodstuff> weightedFoodstuffs = new ArrayList<>();
+                    for (int index = 0; index < foodstuffs.size(); ++index) {
+                        weightedFoodstuffs.add(
+                                foodstuffs.get(index).withWeight(weights.get(index)));
+                    }
+                    add(weightedFoodstuffs);
+                });
     }
 
     public List<WeightedFoodstuff> getList() {
         return Collections.unmodifiableList(bucketList);
     }
 
-    public void add(List<WeightedFoodstuff> wf) {
-        for (WeightedFoodstuff f : wf) {
-            add(f);
+    public void add(List<WeightedFoodstuff> wfs) {
+        checkCurrentThread();
+        bucketList.addAll(wfs);
+        updatePersistentState();
+        for (WeightedFoodstuff wf : wfs) {
+            for (Observer observer : observers) {
+                observer.onFoodstuffAdded(wf);
+            }
         }
     }
 
     public void add(WeightedFoodstuff wf) {
         checkCurrentThread();
         bucketList.add(wf);
+        updatePersistentState();
         for (Observer observer : observers) {
             observer.onFoodstuffAdded(wf);
         }
@@ -48,6 +92,7 @@ public class BucketList {
     public void remove(WeightedFoodstuff wf) {
         checkCurrentThread();
         bucketList.remove(wf);
+        updatePersistentState();
         for (Observer observer : observers) {
             observer.onFoodstuffRemoved(wf);
         }
@@ -57,11 +102,26 @@ public class BucketList {
         checkCurrentThread();
         List<WeightedFoodstuff> removedList = new ArrayList<>(bucketList);
         bucketList.clear();
+        updatePersistentState();
         for (WeightedFoodstuff wf : removedList) {
             for (Observer observer : observers) {
                 observer.onFoodstuffRemoved(wf);
             }
         }
+    }
+
+    private void updatePersistentState() {
+        List<Long> ids = new ArrayList<>();
+        List<Float> weights = new ArrayList<>();
+        for (int index = 0; index < bucketList.size(); ++index) {
+            ids.add(bucketList.get(index).getId());
+            weights.add((float)bucketList.get(index).getWeight());
+            if (ids.get(index) == -1) {
+                throw new IllegalStateException("Cannot have foodstuffs without ids in bucket list");
+            }
+        }
+        prefsManager.putLongList(PrefsOwner.BUCKET_LIST, PREFS_FOODSTUFFS_IDS, ids);
+        prefsManager.putFloatList(PrefsOwner.BUCKET_LIST, PREFS_FOODSTUFFS_WEIGHTS, weights, PERSISTENT_WEIGHT_PRECISION);
     }
 
     public void addObserver(Observer o) {
@@ -75,6 +135,9 @@ public class BucketList {
     }
 
     private void checkCurrentThread() {
+        if (TestEnvironmentDetector.isInTests()) {
+            return;
+        }
         if (Thread.currentThread().getId() != Looper.getMainLooper().getThread().getId()) {
             throw new WrongThreadException("Can't invoke BucketList's methods from not UI thread");
         }

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenCardController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenCardController.java
@@ -93,13 +93,14 @@ public class MainScreenCardController implements FragmentCallbacks.Observer {
             BaseFragment fragment,
             FragmentCallbacks fragmentCallbacks,
             Lifecycle lifecycle,
+            BucketList bucketList,
             HistoryWorker historyWorker,
             TimeProvider timeProvider,
             MainActivitySelectedDateStorage selectedDateStorage) {
         this.context = context;
         this.fragment = fragment;
         this.lifecycle = lifecycle;
-        this.bucketList = BucketList.getInstance();
+        this.bucketList = bucketList;
         this.historyWorker = historyWorker;
         this.timeProvider = timeProvider;
         this.selectedDateStorage = selectedDateStorage;

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenSearchController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenSearchController.java
@@ -86,6 +86,7 @@ public class MainScreenSearchController
     @Inject
     public MainScreenSearchController(
             MainThreadExecutor mainThreadExecutor,
+            BucketList bucketList,
             FoodstuffsList foodstuffsList,
             BaseFragment fragment,
             ActivityCallbacks activityCallbacks,
@@ -94,7 +95,7 @@ public class MainScreenSearchController
             MainScreenReadinessDispatcher mainScreenReadinessDispatcher,
             RxActivitySubscriptions activitySubscriptions) {
         this.mainThreadExecutor = mainThreadExecutor;
-        this.bucketList = BucketList.getInstance();
+        this.bucketList = bucketList;
         this.foodstuffsList = foodstuffsList;
         this.context = fragment.getActivity();
         this.activityCallbacks = activityCallbacks;

--- a/app/src/test/java/korablique/recipecalculator/model/FoodstuffsListTest.java
+++ b/app/src/test/java/korablique/recipecalculator/model/FoodstuffsListTest.java
@@ -12,6 +12,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import korablique.recipecalculator.BuildConfig;
@@ -246,5 +247,38 @@ public class FoodstuffsListTest {
             finishCallback.onFinish();
         }
         Assert.assertEquals(dbFoodstuffs, gettingFoodstuffs);
+    }
+
+    @Test
+    public void testGetFoodstuffsWithId() {
+        dbFoodstuffs.add(Foodstuff.withId(1L).withName("pen").withNutrition(1, 2, 3, 4));
+        dbFoodstuffs.add(Foodstuff.withId(2L).withName("apple").withNutrition(1, 2, 3, 4));
+        dbFoodstuffs.add(Foodstuff.withId(3L).withName("applepen").withNutrition(1, 2, 3, 4));
+
+        List<Foodstuff> foundFoodstuffs =
+                foodstuffsList.getFoodstuffsWithIds(Arrays.asList(1L, 3L)).toList().blockingGet();
+        Assert.assertEquals(2, foundFoodstuffs.size());
+        Assert.assertEquals(foundFoodstuffs.get(0), dbFoodstuffs.get(0));
+        Assert.assertEquals(foundFoodstuffs.get(1), dbFoodstuffs.get(2));
+    }
+
+    @Test
+    public void testGetsFoodstuffsWithIdInRequestedOreder() {
+        dbFoodstuffs.add(Foodstuff.withId(1L).withName("applepen").withNutrition(1, 2, 3, 4));
+        dbFoodstuffs.add(Foodstuff.withId(2L).withName("pinapplepen").withNutrition(1, 2, 3, 4));
+
+        // Прямой порядок
+        List<Foodstuff> foundFoodstuffs =
+                foodstuffsList.getFoodstuffsWithIds(Arrays.asList(1L, 2L)).toList().blockingGet();
+        Assert.assertEquals(2, foundFoodstuffs.size());
+        Assert.assertEquals(foundFoodstuffs.get(0), dbFoodstuffs.get(0));
+        Assert.assertEquals(foundFoodstuffs.get(1), dbFoodstuffs.get(1));
+
+        // Обратный порядок
+        foundFoodstuffs =
+                foodstuffsList.getFoodstuffsWithIds(Arrays.asList(2L, 1L)).toList().blockingGet();
+        Assert.assertEquals(2, foundFoodstuffs.size());
+        Assert.assertEquals(foundFoodstuffs.get(0), dbFoodstuffs.get(1));
+        Assert.assertEquals(foundFoodstuffs.get(1), dbFoodstuffs.get(0));
     }
 }

--- a/app/src/test/java/korablique/recipecalculator/ui/DecimalUtilsTest.kt
+++ b/app/src/test/java/korablique/recipecalculator/ui/DecimalUtilsTest.kt
@@ -1,0 +1,37 @@
+package korablique.recipecalculator.ui
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+import korablique.recipecalculator.BuildConfig
+import org.junit.Assert.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class)
+class DecimalUtilsTest {
+    @Test
+    fun `by default to decimal str with 1 digit after dot`() {
+        val str = DecimalUtils.toDecimalString(123.123)
+        assertEquals("123.1", str)
+    }
+
+    @Test
+    fun `to decimal str with 0 digits after dot`() {
+        val str = DecimalUtils.toDecimalString(123.123, 0)
+        assertEquals("123", str)
+    }
+
+    @Test
+    fun `to decimal str with 2 digits after dot`() {
+        val str = DecimalUtils.toDecimalString(123.123, 2)
+        assertEquals("123.12", str)
+    }
+
+    @Test
+    fun `to decimal str with 1 digit after dot puts no digits when digits are 0`() {
+        val str = DecimalUtils.toDecimalString(123.023, 1)
+        assertEquals("123", str)
+    }
+}


### PR DESCRIPTION
Переработка BucketList'а, исправление бага неизменения массы продукта в bucket list'е при редактировании массы в BucketListActivity (https://trello.com/c/ULzcqEp0).

Примерный список изменений:
- BucketList теперь не классический java-синглтон, а Dagger-синглтон,
- SelectedFoodstuffsSnackbar теперь не сохраняет продукты в saved instance state и не восстанавливает их из него,
- BucketList каждый раз при обновлении своих продуктов сохраняет их в shared preferences, при своём конструировании (т.е. на старте приложения) восстанавлиает продукты из shared preferences,
- Чтобы работу с shared preferences было не так сложно сделать, создан класс SharedPrefsManager, предоставляющий удобные методы для сохранения коллекций float'ов и long'ов в shared preferences,
- ...гора мелких изменений, вызванных изменениями выше.