### PR TITLE
Убрано визуальное дёрганье карточки продукта из-за системной клавиатуры

### DIFF
--- a/app/src/androidTest/java/korablique/recipecalculator/base/SoftKeyboardStateWatcherTest.kt
+++ b/app/src/androidTest/java/korablique/recipecalculator/base/SoftKeyboardStateWatcherTest.kt
@@ -1,0 +1,105 @@
+package korablique.recipecalculator.base
+
+import android.content.Context
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import junit.framework.Assert.assertFalse
+import korablique.recipecalculator.R
+import korablique.recipecalculator.test.SoftKeyboardStateWatcherTestActivity
+import korablique.recipecalculator.ui.KeyboardHandler
+import korablique.recipecalculator.util.InjectableActivityTestRule
+import korablique.recipecalculator.util.SyncMainThreadExecutor
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class SoftKeyboardStateWatcherTest {
+    private lateinit var context: Context
+    private val mainThreadExecutor = SyncMainThreadExecutor()
+    private lateinit var softKeyboardWatcher: SoftKeyboardStateWatcher
+
+    @get:Rule
+    val activityRule: ActivityTestRule<SoftKeyboardStateWatcherTestActivity> =
+            InjectableActivityTestRule.forActivity(SoftKeyboardStateWatcherTestActivity::class.java)
+                    .withSingletones {
+                        context = InstrumentationRegistry.getInstrumentation().getTargetContext()
+                        val currentActivityProvider = CurrentActivityProvider()
+                        listOf(currentActivityProvider)
+                    }
+                    .withActivityScoped { target ->
+                        softKeyboardWatcher =
+                                SoftKeyboardStateWatcher(target as BaseActivity, mainThreadExecutor)
+                        listOf(softKeyboardWatcher)
+                    }
+                    .build()
+
+
+    @Test
+    fun showingKeyboardStateWatchingTest() {
+        var notified = false
+        softKeyboardWatcher.addObserver(object : SoftKeyboardStateWatcher.Observer {
+            override fun onKeyboardProbablyShown() {
+                notified = true
+            }
+        })
+
+        assertFalse(softKeyboardWatcher.isSoftKeyboardShown)
+        assertFalse(notified)
+
+        onView(withId(R.id.normal_edit_text)).perform(click())
+
+        assertTrue(softKeyboardWatcher.isSoftKeyboardShown)
+        assertTrue(notified)
+    }
+
+    @Test
+    fun hidingKeyboardStateWatchingTest() {
+        // Showing keyboard
+        onView(withId(R.id.normal_edit_text)).perform(click())
+
+        var notified = false
+        softKeyboardWatcher.addObserver(object : SoftKeyboardStateWatcher.Observer {
+            override fun onKeyboardProbablyHidden() {
+                notified = true
+            }
+        })
+
+        assertTrue(softKeyboardWatcher.isSoftKeyboardShown)
+        assertFalse(notified)
+
+        mainThreadExecutor.execute {
+            KeyboardHandler(activityRule.activity).hideKeyBoard()
+        }
+
+        Thread.sleep(500) // Giving time to system keyboard
+        assertFalse(softKeyboardWatcher.isSoftKeyboardShown)
+        assertTrue(notified)
+    }
+
+    @Test
+    fun closesKeyboardAndCallsCallback() {
+        // Showing keyboard
+        onView(withId(R.id.normal_edit_text)).perform(click())
+
+        assertTrue(softKeyboardWatcher.isSoftKeyboardShown)
+
+        var notified = false
+        mainThreadExecutor.execute {
+            softKeyboardWatcher.hideKeyboardAndCall(timeoutMillis = 500) {
+                notified = true
+            }
+        }
+
+        Thread.sleep(500) // Giving time to system keyboard
+        assertFalse(softKeyboardWatcher.isSoftKeyboardShown)
+        assertTrue(notified)
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/test/SoftKeyboardStateWatcherTestActivity.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/test/SoftKeyboardStateWatcherTestActivity.java
@@ -1,0 +1,11 @@
+package korablique.recipecalculator.test;
+
+import korablique.recipecalculator.R;
+import korablique.recipecalculator.base.BaseActivity;
+
+public class SoftKeyboardStateWatcherTestActivity extends BaseActivity {
+    @Override
+    protected Integer getLayoutId() {
+        return R.layout.soft_keyboard_state_watcher_test_activity;
+    }
+}

--- a/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityTestsBase.java
+++ b/app/src/androidTest/java/korablique/recipecalculator/ui/mainactivity/MainActivityTestsBase.java
@@ -24,6 +24,7 @@ import korablique.recipecalculator.base.CurrentActivityProvider;
 import korablique.recipecalculator.base.FragmentCallbacks;
 import korablique.recipecalculator.base.RxActivitySubscriptions;
 import korablique.recipecalculator.base.RxFragmentSubscriptions;
+import korablique.recipecalculator.base.SoftKeyboardStateWatcher;
 import korablique.recipecalculator.base.executors.ComputationThreadsExecutor;
 import korablique.recipecalculator.base.executors.MainThreadExecutor;
 import korablique.recipecalculator.base.prefs.PrefsCleaningHelper;
@@ -90,6 +91,7 @@ public class MainActivityTestsBase {
     protected SessionController sessionController;
     protected MainScreenCardController mainScreenCardController;
     protected SharedPrefsManager prefsManager;
+    protected SoftKeyboardStateWatcher softKeyboardStateWatcher;
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityRule =
@@ -128,6 +130,7 @@ public class MainActivityTestsBase {
                                 activity, activityCallbacks, sessionController, timeProvider);
                         fragmentsController = new MainActivityFragmentsController(
                                 activity, sessionController, activityCallbacks);
+                        softKeyboardStateWatcher = new SoftKeyboardStateWatcher(activity, mainThreadExecutor);
                         MainActivityController controller = new MainActivityController(
                                 activity, activityCallbacks, fragmentsController);
                         activitySubscriptions = new RxActivitySubscriptions(activityCallbacks);
@@ -155,7 +158,7 @@ public class MainActivityTestsBase {
                             MainScreenSearchController searchController = new MainScreenSearchController(
                                     mainThreadExecutor, bucketList, foodstuffsList, fragment, activity.getActivityCallbacks(),
                                     fragmentCallbacks, mainScreenCardController, readinessDispatcher,
-                                    activitySubscriptions);
+                                    activitySubscriptions, softKeyboardStateWatcher);
 
                             UpFABController upFABController = new UpFABController(
                                     fragmentCallbacks, readinessDispatcher);

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -10,5 +10,7 @@
         <activity
             android:name=".test.CalcKeyboardTestActivity">
         </activity>
+
+        <activity android:name=".test.SoftKeyboardStateWatcherTestActivity"/>
     </application>
 </manifest>

--- a/app/src/debug/res/layout/soft_keyboard_state_watcher_test_activity.xml
+++ b/app/src/debug/res/layout/soft_keyboard_state_watcher_test_activity.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:tag="calc_keyboard_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="normal edit text"/>
+    <EditText
+        android:id="@+id/normal_edit_text"
+        style="@style/RobotoMonoText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/java/korablique/recipecalculator/base/SoftKeyboardStateWatcher.kt
+++ b/app/src/main/java/korablique/recipecalculator/base/SoftKeyboardStateWatcher.kt
@@ -1,0 +1,158 @@
+package korablique.recipecalculator.base
+
+import android.graphics.Rect
+import android.view.View
+import korablique.recipecalculator.base.executors.MainThreadExecutor
+import korablique.recipecalculator.dagger.ActivityScope
+import korablique.recipecalculator.ui.KeyboardHandler
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.inject.Inject
+
+/**
+ * Следит за состоянием системной экранной клавиатуры.
+ * Важно, что в Андроиде отсутствуют системные средства для получения и отслеживания состояния
+ * экранной клавиатуры, поэтому _все_ значения и уведомления, полученные из этого класса,
+ * далеко не стопроцентны.
+ * От этого, если какая-то логика завязана на этот класс, всегда стоит иметь запасной план.
+ */
+@ActivityScope
+class SoftKeyboardStateWatcher {
+    private val context: BaseActivity
+    private val mainThreadExecutor: MainThreadExecutor
+
+    private val observers = CopyOnWriteArrayList<Observer>()
+    private val keyboardHiddenCallbacks = CopyOnWriteArrayList<()->Unit>()
+
+    var isSoftKeyboardShown: Boolean = false
+        private set
+
+    interface Observer {
+        fun onKeyboardProbablyHidden() {}
+        fun onKeyboardProbablyShown() {}
+    }
+
+    @Inject
+    constructor(
+            activity: BaseActivity,
+            mainThreadExecutor: MainThreadExecutor) {
+        this.context = activity
+        this.mainThreadExecutor = mainThreadExecutor
+
+        val rootLayout: View = activity.findViewById(android.R.id.content)
+        rootLayout.viewTreeObserver.addOnGlobalLayoutListener(this::onGlobalLayout)
+
+        // Делаем вид, что случился onGlobalLayout,
+        // чтобы закешировать состояние показанности клавиатуры.
+        onGlobalLayout()
+    }
+
+    fun addObserver(observer: Observer) {
+        observers.add(observer)
+    }
+
+    fun removeObserver(observer: Observer) {
+        observers.remove(observer)
+    }
+
+    /**
+     * @param callback колбек, который будет вызван когда клавиатура пропадёт, либо через timeoutMillis
+     * @param timeoutMillis время, через которое переданный колбек будет вызван, даже если мы не получили
+     * сигнал от ОСи о закрытии клавиатуры
+     */
+    fun hideKeyboardAndCall(timeoutMillis: Long, callback: ()->Unit) {
+        hideKeyboardAndCallImpl(timeoutMillis, callback, clearViewFocus = true)
+    }
+
+    /**
+     * @see hideKeyboardAndCall
+     */
+    fun hideKeyboardAndCall(timeoutMillis: Long, callback: Runnable) {
+        hideKeyboardAndCall(timeoutMillis, callback::run)
+    }
+
+    /**
+     * То же, что #hideKeyboardAndCall, но при закрытии клавиатуры не очищается
+     * фокус с сфокусированной вьюшки
+     * @see hideKeyboardAndCall
+     */
+    fun hideKeyboardWithoutClearingFocusAndCall(timeoutMillis: Long, callback: ()->Unit) {
+        hideKeyboardAndCallImpl(timeoutMillis, callback, clearViewFocus = false)
+    }
+
+    /**
+     * @see hideKeyboardWithoutClearingFocusAndCall
+     */
+    fun hideKeyboardWithoutClearingFocusAndCall(timeoutMillis: Long, callback: Runnable) {
+        hideKeyboardWithoutClearingFocusAndCall(timeoutMillis, callback::run)
+    }
+
+    private fun hideKeyboardAndCallImpl(timeoutMillis: Long, callback: ()->Unit, clearViewFocus: Boolean) {
+        if (!isSoftKeyboardShown) {
+            callback.invoke()
+            return
+        }
+
+        // Запомним колбек
+        keyboardHiddenCallbacks.add(callback)
+        // Если через timeoutMillis клавиатура всё ещё не спрятана,
+        // всё равно вызовем колбек
+        mainThreadExecutor.executeDelayed(timeoutMillis) {
+            val removed = keyboardHiddenCallbacks.remove(callback)
+            if (removed) {
+                // Если removed, то колбек ещё не вызван, т.к. всё ещё лежал
+                // в keyboardHiddenCallbacks
+                callback.invoke()
+            }
+        }
+
+        if (clearViewFocus) {
+            KeyboardHandler(context).hideKeyBoard()
+        } else {
+            KeyboardHandler(context).hideKeyBoardWithoutClearingFocus()
+        }
+    }
+
+    /**
+     * Весь код с вычислением высоты клавиатуры сворован из https://stackoverflow.com/a/37948358
+     */
+    private fun onGlobalLayout() {
+        val rootLayout: View = context.findViewById(android.R.id.content)
+        val window = context.window
+        val resources = context.resources
+
+        // navigation bar height
+        var navigationBarHeight = 0
+        var resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        if (resourceId > 0) {
+            navigationBarHeight = resources.getDimensionPixelSize(resourceId)
+        }
+
+        // status bar height
+        var statusBarHeight = 0
+        resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
+        if (resourceId > 0) {
+            statusBarHeight = resources.getDimensionPixelSize(resourceId)
+        }
+
+        // display window size for the app layout
+        val rect = Rect()
+        window.decorView.getWindowVisibleDisplayFrame(rect)
+
+        // keyboard height = screen height - (user app height + status + nav)
+        val keyboardHeight = rootLayout.rootView.height - (statusBarHeight + navigationBarHeight + rect.height())
+
+        // if non-zero, then there is a soft keyboard
+        val wasSoftKeyboardShown = isSoftKeyboardShown
+        isSoftKeyboardShown = keyboardHeight > 0
+
+        if (isSoftKeyboardShown != wasSoftKeyboardShown) {
+            if (isSoftKeyboardShown) {
+                observers.forEach { it.onKeyboardProbablyShown() }
+            } else {
+                observers.forEach { it.onKeyboardProbablyHidden() }
+                keyboardHiddenCallbacks.forEach { it.invoke() }
+                keyboardHiddenCallbacks.clear()
+            }
+        }
+    }
+}

--- a/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenSearchController.java
+++ b/app/src/main/java/korablique/recipecalculator/ui/mainactivity/mainscreen/MainScreenSearchController.java
@@ -23,6 +23,7 @@ import korablique.recipecalculator.base.ActivityCallbacks;
 import korablique.recipecalculator.base.BaseFragment;
 import korablique.recipecalculator.base.FragmentCallbacks;
 import korablique.recipecalculator.base.RxActivitySubscriptions;
+import korablique.recipecalculator.base.SoftKeyboardStateWatcher;
 import korablique.recipecalculator.base.executors.MainThreadExecutor;
 import korablique.recipecalculator.dagger.FragmentScope;
 import korablique.recipecalculator.database.FoodstuffsList;
@@ -42,6 +43,7 @@ public class MainScreenSearchController
     private final MainScreenCardController cardController;
     private final MainScreenReadinessDispatcher mainScreenReadinessDispatcher;
     private final RxActivitySubscriptions activitySubscriptions;
+    private final SoftKeyboardStateWatcher softKeyboardStateWatcher;
     private FloatingSearchView searchView;
 
     private BucketList.Observer bucketListObserver = new BucketList.Observer() {
@@ -93,7 +95,8 @@ public class MainScreenSearchController
             FragmentCallbacks fragmentCallbacks,
             MainScreenCardController cardController,
             MainScreenReadinessDispatcher mainScreenReadinessDispatcher,
-            RxActivitySubscriptions activitySubscriptions) {
+            RxActivitySubscriptions activitySubscriptions,
+            SoftKeyboardStateWatcher softKeyboardStateWatcher) {
         this.mainThreadExecutor = mainThreadExecutor;
         this.bucketList = bucketList;
         this.foodstuffsList = foodstuffsList;
@@ -102,6 +105,7 @@ public class MainScreenSearchController
         this.cardController = cardController;
         this.mainScreenReadinessDispatcher = mainScreenReadinessDispatcher;
         this.activitySubscriptions = activitySubscriptions;
+        this.softKeyboardStateWatcher = softKeyboardStateWatcher;
         fragmentCallbacks.addObserver(this);
 
         cardController.addObserver(new MainScreenCardController.Observer() {
@@ -159,7 +163,10 @@ public class MainScreenSearchController
             @Override
             public void onSuggestionClicked(SearchSuggestion searchSuggestion) {
                 FoodstuffSearchSuggestion suggestion = (FoodstuffSearchSuggestion) searchSuggestion;
-                cardController.showCard(suggestion.getFoodstuff());
+                long keyboardWaitingTimeout = 500;
+                softKeyboardStateWatcher.hideKeyboardWithoutClearingFocusAndCall(keyboardWaitingTimeout, () -> {
+                    cardController.showCard(suggestion.getFoodstuff());
+                });
             }
             // когда пользователь нажал на клавиатуре enter
             @Override


### PR DESCRIPTION
Убрано визуальное дёрганье карточки продукта из-за системной клавиатуры (https://trello.com/c/yzMwL6E9).

Суть правки - при клике на подсказку в результатах поиска, прячем системную клавиатуру и ждём её закрытия, только потом показываем карточку.